### PR TITLE
Fix modal behavior and enhance workout details display

### DIFF
--- a/src/components/WorkoutDetailsModal.tsx
+++ b/src/components/WorkoutDetailsModal.tsx
@@ -5,8 +5,8 @@ import { useFetch } from "@/hooks/useFetch";
 import type { WorkoutResponseModel } from "@/types/workout";
 
 type WorkoutDetails = WorkoutResponseModel & {
-   description?: string | null; // camelCase
-   Description?: string | null; // PascalCase (om backend råkar skicka så)
+   description?: string | null;
+   Description?: string | null;
 };
 
 // Props för WorkoutDetailsModal
@@ -30,24 +30,51 @@ const WorkoutDetailsModal: React.FC<Props> = ({
       ? `https://workout-api-h8aae7hfcaghgvdb.swedencentral-01.azurewebsites.net/api/workout/${workoutId}`
       : null;
 
+      // Logga endpoint för felsökning
+      if (shouldFetch) {
+         console.debug("WorkoutDetailsModal endpoint:", endpoint);
+         }
+
    const { data, loading, error } = useFetch<WorkoutDetails>(endpoint);
 
-   // 1) Om camelCase finns och inte är tomt -> använd den
-   // 2) Annars kolla PascalCase på ett säkert sätt via unknown-cast
-   const pascalMaybe = (data as unknown as { Description?: unknown } | null)
-      ?.Description;
+   const description = data?.description || data?.Description || "Ingen beskrivning tillagd ännu.";
 
-   // Bestäm beskrivning att visa: prioritera camelCase, fallback till PascalCase
-   const desc =
-      typeof data?.description === "string" && data.description.trim() !== ""
-         ? data.description
-         : typeof pascalMaybe === "string" && pascalMaybe.trim() !== ""
-         ? pascalMaybe
-         : undefined;
+   // Hjälpfunktion för att formatera datum och tid på svenska
+   const formatTimeDate = (dateString: string) => {
+      const date = new Date(dateString);
+
+      const weekday = date.toLocaleDateString("sv-SE", {
+         weekday: "long",
+         timeZone: "Europe/Stockholm",
+      });
+
+      const dayMonth = date.toLocaleDateString("sv-SE", {
+         day: "numeric",
+         month: "long",
+         timeZone: "Europe/Stockholm",
+      });
+
+      const time = date.toLocaleTimeString("sv-SE", {
+         hour: "2-digit",
+         minute: "2-digit",
+         hour12: false,
+         timeZone: "Europe/Stockholm",
+      });
+
+      const capitalize = (str: string) => str.charAt(0).toUpperCase() + str.slice(1);
+
+      // Returnerar både full datumsträng och tid samt en11 aria-label
+      return {
+         fullDate: `${capitalize(weekday)}, ${dayMonth}`,
+         time,
+         ariaLabel: `${capitalize(weekday)}, ${dayMonth} klockan ${time}`,
+      };
+   };
+   
+   const dateTime = data ? formatTimeDate(data.startTime) : null;
 
    if (!isOpen) return null;
 
-   // Rendera modalen med olika tillstånd: laddar, fel, data eller tomt
    return (
       <Modal
          isOpen={isOpen}
@@ -55,27 +82,45 @@ const WorkoutDetailsModal: React.FC<Props> = ({
          heading={data?.title || "Detaljer"}
       >
          {loading ? (
-            <div className="modal-loading">
+            <div className="modal-loading" role="status" aria-live="polite">
                <Spinner />
+               <span className="sr-only">Laddar träningsinfomration...</span>
             </div>
          ) : error ? (
-            <div className="modal-error">{`Kunde inte ladda: ${error}`}</div>
-         ) : data ? (
-            <div className="modal-content">
-               <p>
-               <p>
-                  <strong>Instruktör:</strong> {data.instructor}
-               </p>
-                  <strong>Tid:</strong>{" "}
-                  {new Date(data.startTime).toLocaleString()}
-               </p>
-               <p>
-                  <strong>Plats:</strong> {data.location}
-               </p>
+            <div className="modal-error" role="alert">
+               Kunde inte ladda: {error}
+            </div>
+         ) : data && dateTime ? (
+            <div className="modal-content">            
+               <div className="modal-row">
+                  <i className="fa-solid fa-chalkboard-user icon" aria-hidden="true" />      
+                  <span>
+                     <span className="sr-only">Instruktör:</span>                  
+                     {data.instructor}
+                  </span>
+               </div>
 
-               {/* Beskrivning: rendera alltid blocket, visa fallback-text om tomt */}
-               <div className="modal-description">                                   
-                  <p>{desc ?? "Ingen beskrivning tillagd ännu."}</p>
+               <div className="modal-row" aria-label={dateTime.ariaLabel}>
+                  <i className="fa-solid fa-clock icon" aria-hidden="true" />
+                  <span aria-hidden="true">
+                     {dateTime.fullDate}
+                     <span className="dot">•</span>
+                     <strong>{dateTime.time}</strong>
+                  </span>                  
+               </div>
+
+               <div className="modal-row">
+                  <i className="fa-solid fa-location-dot icon" aria-hidden="true" />
+                  <span>
+                     <span className="sr-only">Plats:</span>
+                     {data.location}
+                  </span>
+               </div>
+
+               <div className="modal-description">
+                  <h3 className="sr-only">Beskrivning</h3>
+                  <p>{description}</p>
+                  {/* <p>{desc ?? "Ingen beskrivning tillagd ännu."}</p> */}
                </div>
 
                <div className="modal-actions">
@@ -83,13 +128,16 @@ const WorkoutDetailsModal: React.FC<Props> = ({
                      className="primary-button"
                      onClick={onClose}
                      type="button"
+                     aria-label="Stäng detaljer om träningspass"
                   >
                      Stäng
                   </button>
                </div>
             </div>
          ) : (
-            <div className="modal-empty">Inga detaljer att visa.</div>
+            <div className="modal-empty" role="status">
+               Inga detaljer att visa.
+            </div>
          )}
       </Modal>
    );

--- a/src/components/WorkoutItem.tsx
+++ b/src/components/WorkoutItem.tsx
@@ -7,7 +7,7 @@ type WorkoutItemProps = {
   index: number;
   isBooked: boolean;
   onBookingChanged: () => void; 
-  onViewDetails?: (workoutId: string) => void; // optional callback for viewing details
+  onViewDetails?: (workoutId: string) => void;
 };
 
 const BOOKINGS_API_BASE =
@@ -105,8 +105,29 @@ const WorkoutItemComponent: React.FC<WorkoutItemProps> = ({
       <td className="px-6 py-4">
         <button
           // Använder de dynamiskt valda klasserna
-          className={buttonClasses}
-          onClick={isBooked ? handleCancelWorkout : handleBookWorkout}
+          className={buttonClasses}      
+          onClick={(e: React.MouseEvent<HTMLButtonElement>) => { 
+            e.stopPropagation();
+            // Hanterar både bokning och avbokning
+            if (isBooked) {
+              handleCancelWorkout();
+            } else {
+              handleBookWorkout();
+            }
+          }}
+          // Gör knappen åtkomlig via tangentbordet
+          onKeyDown={(e: React.KeyboardEvent<HTMLButtonElement>) => {
+            e.stopPropagation();
+            if (e.key === "Enter" || e.key === " ") {
+              e.preventDefault();
+              // Hanterar både bokning och avbokning
+              if (isBooked) {
+                handleCancelWorkout();
+              } else {
+                handleBookWorkout();
+              }
+            }
+          }}
           disabled={isLoading}
           // Översatta aria-labels
           aria-label={

--- a/src/components/WorkoutItem.tsx
+++ b/src/components/WorkoutItem.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { formatDateTime } from "@/lib/utils/formatDateTimeUtil";
+// import { formatDateTime } from "@/lib/utils/formatDateTimeUtil";
 import type { WorkoutResponseModel } from "@/types/workout";
 
 type WorkoutItemProps = {
@@ -98,8 +98,32 @@ const WorkoutItemComponent: React.FC<WorkoutItemProps> = ({
     >
       <td className="px-6 py-4 text-gray-800">{workout.title}</td>
       <td className="px-6 py-4 text-gray-700">{workout.location}</td>
+      
+      {/* Anpassad datum- och tidsformattering för svenska (Sverige) */}
       <td className="px-6 py-4 text-gray-700">
-        {formatDateTime(workout.startTime)}
+        {(() => {
+          const d = new Date(workout.startTime);
+          const dateLabel = d.toLocaleDateString("sv-SE", {
+            weekday: 'short',
+            year: 'numeric',
+            month: 'short',
+            day: 'numeric',
+          });
+          const timeLabel = d.toLocaleTimeString("sv-SE", {
+            hour: '2-digit',
+            minute: '2-digit',
+            hour12: false,
+            timeZone: 'Europe/Stockholm',
+          });
+          const cap = (s: string) => s.charAt(0).toUpperCase() + s.slice(1);
+
+          return (
+            <div className="flex items-center justify-between gap-6">
+              <span className="text-gray-700">{cap(dateLabel)}</span>
+              <span className="font-semibold">{timeLabel}</span>
+            </div>
+          );
+        })()}        
       </td>
       <td className="px-6 py-4 text-gray-700">{workout.instructor}</td>
       <td className="px-6 py-4">

--- a/src/css/modal.css
+++ b/src/css/modal.css
@@ -5,12 +5,12 @@
    position: fixed;
    inset: 0;
    z-index: 1000;
-   display: block;
    background: rgba(0, 0, 0, 0.5);
    animation: overlay-fade var(--motion-duration-normal) ease-out;
+   display: flex;
+   align-items: flex-end;
 
    @media (min-width: 640px) {
-      display: flex;
       align-items: center;
       justify-content: center;
    }
@@ -28,34 +28,26 @@
 
 /* ================================
    Modal (container)
-   - Fullscreen på mobil, centrerad på ≥640px
 ================================ */
 .modal {
-   position: relative;
-   isolation: isolate;
-   inset: 0;
+   position: relative;      
    width: 100dvw;
-   height: 100dvh;
-   margin: 0;
-   max-width: none;
-   max-height: none;
-   border-radius: 0;
+   height: 100dvh;      
+   display: flex;
+   flex-direction: column;
+   border-radius: 0;   
    background: var(--clr-bg-card);
    color: var(--clr-text);
    box-shadow: none;
-   display: flex;
-   flex-direction: column;
    
    /* Entré-animering mobil: lätt fade + slide */
    opacity: 0;
-   transform: translateY(8px);
-   animation: modal-in-mobile var(--motion-duration-slow) cubic-bezier(.2,.7,.2,1) forwards;
-   will-change: transform, opacity;
+   transform: translateY(100%);
+   animation: modal-in-mobile var(--motion-duration-slow) cubic-bezier(0.2, 0.7, 0.2, 1) forwards;
 
    @media (min-width: 640px) {
-      max-width: clamp(20rem, 90%, 40rem);
-      height: auto;
-      position: relative;
+      max-width: clamp(20rem, 90%, 34rem);      
+      height: auto; 
       max-height: 90dvh;
       border-radius: 0.75rem;
       box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.25);
@@ -73,14 +65,12 @@
 .modal-header {
    position: sticky;
    top: 0;
-   z-index: 1;
    display: flex;
    align-items: center;
    justify-content: space-between;
    background: inherit;
    box-shadow: none;
-   padding: 0.875rem 1rem;
-   border-bottom: 1px solid var(--clr-border);
+   padding: 0.875rem 1rem;   
    border-radius: 0.75rem 0.75rem 0 0;   
 
    @media (min-width: 640px) {
@@ -103,35 +93,77 @@
 ================================ */
 .modal-body {
    flex: 1;
-   overflow: auto;
-   font-size: 1rem;
+   overflow-y: auto;
+   overflow-x: hidden;   
    padding: 0.875rem 1rem;
-
-   & .modal-content p {
-      font-weight: 500;
-      margin: 0 0 0.5rem 0;
-      line-height: 1.5;
-      color: var(--clr-text-title);
-   }
-
-   .modal-description {
-      margin-top: 2rem;
-      font-weight: 400;
-      color: var(--clr-text-body);
-      line-height: 1.5;
-      font-size: 0.875rem;
-      border-top: 1px solid var(--clr-border);
-
-      & p {
-         margin: 0.5rem 0 0 0;
-         font-weight: 400;
-         color: var(--clr-text-body);
-      }
-   }
+   overscroll-behavior: contain;
 
    @media (min-width: 640px) {
       overflow: auto;
       padding-inline: 1rem;
+   }
+}
+
+
+/* ================================
+   Content
+================================ */
+.modal-content {
+   display: flex;
+   flex-direction: column;
+   gap: 0.75rem;
+
+      & p {
+      margin: 0;
+      font-weight: 600;
+      line-height: 1.5;
+      color: var(--clr-text-title);
+   }
+}
+
+.modal-row {
+   display: flex;
+   align-items: center;
+   gap: 0.5rem;
+   font-weight: 500;
+   line-height: 1.5;
+   color: var(--clr-text-title);
+
+   & .icon {      
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 1.125rem;
+      flex-shrink: 0;
+      font-size: 1rem;      
+      color: var(--clr-text-title);
+      opacity: 0.85;
+      transform: translateY(1px); /* finjustera vertikal position */
+   }
+
+   & .dot {
+      margin: 0 0.25rem;
+      opacity: 0.6;
+   }
+
+   & .time-strong {
+      font-weight: 600;
+   }
+}
+
+
+/* ================================
+   Description
+================================ */
+.modal-description {   
+   margin-top: 1rem;
+   
+   & p {
+      line-height: 1.5;
+      font-size: 0.875rem;
+      margin: 0.5rem 0 0 0;
+      font-weight: 400;
+      color: var(--clr-text-body);
    }
 }
 
@@ -219,24 +251,24 @@
 .modal-loading,
 .modal-empty,
 .modal-error {
-   padding: 1rem;
-}
-
-.modal-loading {
    display: grid;
    place-items: center;
-   min-height: 8rem;
+   min-height: 12rem;
+   padding: 2rem 1rem;
+}
+
+.modal-error {
+   color: var(--clr-error-500);
 }
 
 
 /* ================================
-   Animations + Reduced Motion
+   Animations
 ================================ */
 @keyframes overlay-fade {
    from {
       opacity: 0;
    }
-
    to {
       opacity: 1;
    }
@@ -245,9 +277,8 @@
 @keyframes modal-in-mobile {
    from {
       opacity: 0;
-      transform: translateY(8px);
+      transform: translateY(100%);
    }
-
    to {
       opacity: 1;
       transform: translateY(0);
@@ -257,23 +288,25 @@
 @keyframes modal-in-desktop {
    from {
       opacity: 0;
-      transform: scale(.98);
+      transform: scale(0.96);
    }
-
    to {
       opacity: 1;
       transform: scale(1);
    }
 }
 
+/* ================================
+   Reduced Motion
+================================ */
 @media (prefers-reduced-motion: reduce) {
-
    .modal-overlay,
    .modal {
-      animation: none !important;
+      animation-duration: 0.01ms !important;
    }
 
-   .modal-actions .primary-button {
-      transition: none;
+   .modal-actions .primary-button,
+   .modal-close {
+      transition: none !important;
    }
 }

--- a/src/pages/Workouts.tsx
+++ b/src/pages/Workouts.tsx
@@ -68,14 +68,17 @@ const Workouts: React.FC = () => {
     refetchMyBookings();
   };
 
-  const isLoading = workoutsLoading || bookingsLoading;
+  // Tidigare: workoutsLoading || bookingsLoading -> gav ett kort "flicker" (listan blinkade vid refetch av bokningar). Nu visar vi spinner bara vid initial laddning.
+  const isInitialLoading =
+    workoutsLoading || (bookingsLoading && !myBookings);
   const error = workoutsError || bookingsError;
   const refetch = () => {
     refetchWorkouts();
     if (userEmail) refetchMyBookings();
   };
 
-  if (isLoading) return <Spinner />;
+  // Om initial laddning pågår, visa spinner
+  if (isInitialLoading) return <Spinner />;  
 
   const workouts = Array.isArray(allWorkouts) ? allWorkouts : [];
 


### PR DESCRIPTION
### What

- The details modal now works in My Bookings. We take the `workoutIdentifier` from RawBookings, fetch the workout, and open the modal with full info.
- Gave the modal some love: improved and cleaned-up CSS.
- `WorkoutDetlailsModal` formats date/time nicely in Swedish and has clear loading/error states.

### Why

- Consistent experience no matter where you click, plus a more robust and tidy modal.

### Notes

- There's one extra request per booking when opening the modal. It's fine for now, but we should expose `workoutIdentifier` in `GetMyBookings` or add a batched/detailed bookings endpoint to eliminate the per-click request.